### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/server/src/services/claude-code.js
+++ b/server/src/services/claude-code.js
@@ -41,31 +41,18 @@ class InputValidator {
   }
 
   static async validateWorkingDirectory(workingDir) {
+    const SAFE_ROOT = '/safe/root/dir'; // Define the safe root directory
+
     if (!workingDir || typeof workingDir !== 'string') {
-      return process.cwd();
+      return SAFE_ROOT; // Default to the safe root directory
     }
 
     // Resolve to absolute path
     const resolvedPath = resolve(workingDir);
 
-    // Check if it contains any suspicious patterns
-    const suspiciousPatterns = [
-      '../',
-      '..\\',
-      '/etc/',
-      '/proc/',
-      '/sys/',
-      '/dev/',
-      'C:\\Windows\\',
-      'C:\\Program Files\\',
-      '/usr/bin/',
-      '/sbin/',
-    ];
-
-    for (const pattern of suspiciousPatterns) {
-      if (resolvedPath.includes(pattern)) {
-        throw new Error('Working directory contains suspicious path components');
-      }
+    // Ensure the resolved path is within the safe root directory
+    if (!resolvedPath.startsWith(SAFE_ROOT)) {
+      throw new Error('Working directory must be within the safe root directory');
     }
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/claude-companion/security/code-scanning/14](https://github.com/dock108/claude-companion/security/code-scanning/14)

To fix the issue, we need to ensure that the `workingDirectory` is strictly contained within a predefined safe root directory. This can be achieved by:
1. Defining a safe root directory (e.g., `/safe/root/dir`).
2. Normalizing the `workingDirectory` path using `path.resolve` to remove any `..` segments.
3. Verifying that the normalized path starts with the safe root directory. If it does not, reject the input.

The changes will be made in the `validateWorkingDirectory` method of the `InputValidator` class in `server/src/services/claude-code.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
