### PR TITLE
refactor: hide Claude CLI tab and prevent switching to it

### DIFF
--- a/server/hostapp/index.html
+++ b/server/hostapp/index.html
@@ -23,7 +23,8 @@
         <!-- Tab Navigation -->
         <nav class="tab-nav">
             <button class="tab-button active" data-tab="server">Server</button>
-            <button class="tab-button" data-tab="claude">Claude CLI</button>
+            <!-- Claude CLI tab hidden as we're no longer using interactive mode -->
+            <!-- <button class="tab-button" data-tab="claude">Claude CLI</button> -->
             <button class="tab-button" data-tab="logs">Logs</button>
         </nav>
 

--- a/server/hostapp/src/app-core.js
+++ b/server/hostapp/src/app-core.js
@@ -405,6 +405,12 @@ export function renderLogs() {
 
 // Tab Navigation
 export function switchTab(tabName) {
+  // Prevent switching to hidden Claude tab
+  if (tabName === 'claude') {
+    console.log('Claude tab is currently hidden');
+    return;
+  }
+
   // Update tab buttons
   document.querySelectorAll('.tab-button').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.tab === tabName);
@@ -420,9 +426,11 @@ export function switchTab(tabName) {
   // Load logs when switching to logs tab
   if (tabName === 'logs') {
     loadLogs();
-  } else if (tabName === 'claude') {
-    loadClaudeStatus();
   }
+  // Claude tab functionality preserved but hidden
+  // else if (tabName === 'claude') {
+  //   loadClaudeStatus();
+  // }
 }
 
 // Claude CLI Management


### PR DESCRIPTION
This pull request focuses on disabling the interactive Claude CLI tab in the application interface while preserving its functionality for potential future use. The changes ensure that users cannot access the tab while maintaining the underlying code for the tab's operations.

### Updates to the user interface:

* [`server/hostapp/index.html`](diffhunk://#diff-57bee5cf39edb0601e59e6db9f4d581ab2cbb7882cc46836e1af14942255c575L26-R27): Commented out the Claude CLI tab in the navigation bar to hide it from the user interface, with a note explaining the change.

### Updates to tab-switching logic:

* [`server/hostapp/src/app-core.js`](diffhunk://#diff-93c09bb5d569de96cdf27b8693bbcd3af691c4f47e2efe6e0c21bef9c7d8f695R408-R413): Added a check in the `switchTab` function to prevent switching to the hidden Claude CLI tab, including a console log message for debugging purposes.
* [`server/hostapp/src/app-core.js`](diffhunk://#diff-93c09bb5d569de96cdf27b8693bbcd3af691c4f47e2efe6e0c21bef9c7d8f695L423-R433): Commented out the code responsible for loading the Claude CLI tab's functionality, preserving it for potential reactivation in the future.