### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/server/src/routes/projects.js
+++ b/server/src/routes/projects.js
@@ -16,8 +16,18 @@ export function setupProjectRoutes(app, claudeService) {
     return config.configPath;
   };
 
+  // Define rate limiter for projects list route
+  const projectsListLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    message: {
+      error: 'Too many requests',
+      message: 'Please try again later.',
+    },
+  });
+
   // List all projects (folders) in the configured directory
-  router.get('/projects', async (req, res) => {
+  router.get('/projects', projectsListLimiter, async (req, res) => {
     try {
       const projectsDir = getProjectsDir();
       console.log('Listing projects from directory:', path.basename(projectsDir));


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/claude-companion/security/code-scanning/17](https://github.com/dock108/claude-companion/security/code-scanning/17)

To fix the problem, we should apply a rate-limiting middleware to the `/projects` GET route, similar to how it is done for `/projects/:name`. The best way is to define a rate limiter instance (using `express-rate-limit`) with appropriate configuration (e.g., 100 requests per 15 minutes per IP), and use it as middleware for the `/projects` route. This change should be made in `server/src/routes/projects.js`, near the definition of the `/projects` route. The fix involves:

- Defining a new rate limiter instance (e.g., `projectsListLimiter`) before the route.
- Applying this limiter as middleware to the `/projects` route.
- No changes to existing functionality or logic, just the addition of the rate limiter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
