### PR TITLE
Potential fix for code scanning alert no. 22: Use of externally-controlled format string

### DIFF
--- a/server/src/routes/projects.js
+++ b/server/src/routes/projects.js
@@ -221,7 +221,7 @@ export function setupProjectRoutes(app, claudeService) {
           message: `Claude CLI session started for project '${name}'`,
         });
       } catch (error) {
-        console.error(`Failed to start Claude CLI for project ${name}:`, error);
+        console.error('Failed to start Claude CLI for project %s:', name, error);
 
         // Provide more specific error messages based on the error type
         let statusCode = 500;


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/claude-companion/security/code-scanning/22](https://github.com/dock108/claude-companion/security/code-scanning/22)

To fix this issue, we should avoid passing user-controlled data as part of the format string to `console.error`. Instead, we should use a static format string with a `%s` placeholder and pass the user-controlled value as a separate argument. This ensures that any format specifiers in the user input are treated as literal strings, not as format instructions. Specifically, on line 224, change:

```js
console.error(`Failed to start Claude CLI for project ${name}:`, error);
```

to

```js
console.error('Failed to start Claude CLI for project %s:', name, error);
```

No additional imports or method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
