### PR TITLE
Potential fix for code scanning alert no. 23: Use of externally-controlled format string

### DIFF
--- a/server/src/routes/claude-status.js
+++ b/server/src/routes/claude-status.js
@@ -181,7 +181,7 @@ export function setupClaudeStatusRoutes(app, claudeService) {
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
-      console.error(`Claude CLI debug test (${req.params.testType}) failed:`, error);
+      console.error('Claude CLI debug test failed for testType:', req.params.testType, error);
       res.status(500).json({
         success: false,
         testType: req.params.testType,


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/claude-companion/security/code-scanning/23](https://github.com/dock108/claude-companion/security/code-scanning/23)

To fix the issue, we will ensure that the user-provided value (`req.params.testType`) is sanitized before being included in the log message. This can be achieved by explicitly passing the untrusted value as a separate argument to `console.error` instead of embedding it directly in the template literal. This approach avoids potential log injection issues and ensures that the value is safely logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
