### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/server/src/routes/projects.js
+++ b/server/src/routes/projects.js
@@ -128,8 +128,18 @@ export function setupProjectRoutes(app, claudeService) {
     }
   });
 
+  // Define rate limiter for starting Claude CLI route
+  const startProjectLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // Limit each IP to 50 requests per windowMs
+    message: {
+      error: 'Too many requests',
+      message: 'Please try again later.',
+    },
+  });
+
   // Start Claude CLI in a specific project directory
-  router.post('/projects/:name/start', async (req, res) => {
+  router.post('/projects/:name/start', startProjectLimiter, async (req, res) => {
     try {
       const { name } = req.params;
       const projectsDir = getProjectsDir();


### PR DESCRIPTION
Potential fix for [https://github.com/dock108/claude-companion/security/code-scanning/21](https://github.com/dock108/claude-companion/security/code-scanning/21)

To fix the issue, we will add a rate limiter to the `/projects/:name/start` route. This will limit the number of requests that can be made to this route within a specified time window, preventing abuse. We will use the `express-rate-limit` middleware, which is already imported and used in the file. Specifically:
1. Define a new rate limiter for the `/projects/:name/start` route, similar to the existing rate limiters for other routes.
2. Apply the rate limiter to the route by passing it as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
