### PR TITLE
Update Xcode project configuration

### DIFF
--- a/ios/ClaudeCompanion.xcodeproj/project.pbxproj
+++ b/ios/ClaudeCompanion.xcodeproj/project.pbxproj
@@ -3,21 +3,21 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		5ACF9EB7D38A188D15E60A1B /* ClaudeCompanion in Frameworks */ = {isa = PBXBuildFile; productRef = 8776735A8E24240B6DA6347A /* ClaudeCompanion */; };
-		B7A41D5EFADEF755364338AE /* AppMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF634300745096B81EF609E3 /* AppMain.swift */; };
 		A1B2C3D4E5F67890ABCDEF02 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F67890ABCDEF01 /* Assets.xcassets */; };
+		B7A41D5EFADEF755364338AE /* AppMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF634300745096B81EF609E3 /* AppMain.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		66BAE168410B6951B8045A03 /* ClaudeCompanionApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ClaudeCompanionApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		66BAE168410B6951B8045A03 /* Claude Companion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Claude Companion.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		907290AB1FF6522CFF9193CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9B9275CF280821DE8EF21FDA /* ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ios; path = .; sourceTree = SOURCE_ROOT; };
-		EF634300745096B81EF609E3 /* AppMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMain.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F67890ABCDEF01 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		EF634300745096B81EF609E3 /* AppMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMain.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,7 +53,7 @@
 		C8ACAB04B2A18F5A270D5BDE /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				66BAE168410B6951B8045A03 /* ClaudeCompanionApp.app */,
+				66BAE168410B6951B8045A03 /* Claude Companion.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -87,7 +87,7 @@
 				8776735A8E24240B6DA6347A /* ClaudeCompanion */,
 			);
 			productName = ClaudeCompanionApp;
-			productReference = 66BAE168410B6951B8045A03 /* ClaudeCompanionApp.app */;
+			productReference = 66BAE168410B6951B8045A03 /* Claude Companion.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -100,7 +100,6 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					3FD6860F8D2E9FED827EB39D = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -125,17 +124,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXSourcesBuildPhase section */
-		E4D5A3876C8C358A0B195410 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B7A41D5EFADEF755364338AE /* AppMain.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
 /* Begin PBXResourcesBuildPhase section */
 		A1B2C3D4E5F67890ABCDEF03 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
@@ -146,6 +134,17 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E4D5A3876C8C358A0B195410 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B7A41D5EFADEF755364338AE /* AppMain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		47AA80DBD93132D7B6E81B92 /* Release */ = {
@@ -274,7 +273,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = E3G5D247ZN;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -297,7 +296,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = E3G5D247ZN;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
This pull request updates the `ios/ClaudeCompanion.xcodeproj/project.pbxproj` file to improve project configuration and organization. Key changes include renaming the app reference, assigning a development team, and reorganizing build phases.

### Project Configuration Updates:
- Renamed the app reference from `ClaudeCompanionApp.app` to `"Claude Companion.app"` for better readability and consistency. [[1]](diffhunk://#diff-308d5692c1ff7500d6bf2b46680f4aad139c5cfb7f6dfe7df09364f430c0b088L6-R20) [[2]](diffhunk://#diff-308d5692c1ff7500d6bf2b46680f4aad139c5cfb7f6dfe7df09364f430c0b088L56-R56) [[3]](diffhunk://#diff-308d5692c1ff7500d6bf2b46680f4aad139c5cfb7f6dfe7df09364f430c0b088L90-R90)

### Development Team Assignment:
- Assigned the development team identifier `E3G5D247ZN` to replace the empty `DevelopmentTeam` field, ensuring proper code signing configuration. [[1]](diffhunk://#diff-308d5692c1ff7500d6bf2b46680f4aad139c5cfb7f6dfe7df09364f430c0b088L277-R276) [[2]](diffhunk://#diff-308d5692c1ff7500d6bf2b46680f4aad139c5cfb7f6dfe7df09364f430c0b088L300-R299)

### Build Phase Reorganization:
- Swapped the `PBXSourcesBuildPhase` and `PBXResourcesBuildPhase` sections to correctly categorize `AppMain.swift` under Sources and `Assets.xcassets` under Resources.